### PR TITLE
Added changes from Linear ticket #CF-3659

### DIFF
--- a/config/main.tf
+++ b/config/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     commonfate = {
       source  = "common-fate/commonfate"
-      version = "2.19.0"
+      version = "2.26.1"
     }
   }
 }

--- a/config/policies/default.cedar
+++ b/config/policies/default.cedar
@@ -53,12 +53,3 @@ permit (
     resource
 );
 
-
-permit (
-    principal ==
-        CF::User::<Replace with your own user id from CF web console>,
-    action ==
-        CF::RPC::Action::"commonfate.control.integration.v1alpha1.IntegrationService/ListSyncsForIntegration",
-    resource ==
-        CF::Service::"ControlPlane",
-);

--- a/config/policies/default.cedar
+++ b/config/policies/default.cedar
@@ -45,3 +45,20 @@ forbid (
     resource
 )
 when { principal == resource.principal };
+
+// Allow admins to read all resources
+permit (
+    principal,
+    action in CF::Admin::Action::"Read",
+    resource
+);
+
+
+permit (
+    principal ==
+        CF::User::<Replace with your own user id from CF web console>,
+    action ==
+        CF::RPC::Action::"commonfate.control.integration.v1alpha1.IntegrationService/ListSyncsForIntegration",
+    resource ==
+        CF::Service::"ControlPlane",
+);

--- a/config/policies/default.cedar
+++ b/config/policies/default.cedar
@@ -48,7 +48,7 @@ when { principal == resource.principal };
 
 // Allow admins to read all resources
 permit (
-    principal,
+    principal in Entra::Group::"ID_OF_COMMON_FATE_ADMINISTRATOR_GROUP",
     action in CF::Admin::Action::"Read",
     resource
 );

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,6 +1,6 @@
 module "common-fate-deployment" {
   source  = "common-fate/common-fate-deployment/aws"
-  version = "1.45.2"
+  version = "2.7.1"
 
   aws_region = "us-east-1 <replace this>"
 


### PR DESCRIPTION
Fixed version numbers for terraform providers and added cedar policies according to changes highlighted in Linear ticket: https://linear.app/common-fate/issue/CF-3659/fixes-to-byoc-starter-config

What changed?
Updates CF terraform provider's version numbers and added extra cedar policies for control plane.

Why?
Older CF terraform provider requires an extra argument in other resources that are not documented in config docs. Control plane Cedar policy was required for deployment.

How did you test it?
Tested locally with my own byoc @vignesh.lightwave.dev

Potential risks
low-medium, this is just a starter config that only new teams who might use in the future might have issues with. Local testing does not seem to break anything.

Is patch release candidate?
N/A

Link to relevant docs PRs
N/A