### PR TITLE
CF TF provider's version bump to 2.27.1

### DIFF
--- a/config/main.tf
+++ b/config/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     commonfate = {
       source  = "common-fate/commonfate"
-      version = "2.26.1"
+      version = "2.27.1"
     }
   }
 }


### PR DESCRIPTION
Bumped our CF TF Provider's version number to 2.27.1 to stop "try_extend_after_seconds" errors from appearing for newer users. 